### PR TITLE
add startDate in config api response

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -42,6 +42,7 @@ duration: P10DT (= 10 days)
   ```
   ```json
   {
+    "startDate": "2020-01-01T00:00:00Z",
     "frequency": "PT1H",
     "range": "P10DT"
   }

--- a/internal/api/asset_controller.go
+++ b/internal/api/asset_controller.go
@@ -57,6 +57,7 @@ func (ct *AssetController) Routes(route *gin.RouterGroup) {
 func (ct *AssetController) GetConfiguration(c *gin.Context) {
 	ginlogrus.SetCtxLoggerHeader(c, "request-header", "Get Asset Configuration")
 	c.JSON(http.StatusOK, &AssetConfigResponse{
+		StartDate: ct.config.StartDate,
 		Frequency: iso8601.EncodeDuration(ct.config.Frequency),
 		RangeD:    iso8601.EncodeDuration(ct.config.RangeD),
 	})

--- a/internal/api/asset_controller_test.go
+++ b/internal/api/asset_controller_test.go
@@ -102,6 +102,7 @@ func TestAssetController_GetConfiguration(t *testing.T) {
 	r.ServeHTTP(resp, c.Request)
 	if assert.Equal(t, http.StatusOK, resp.Code) {
 		expected := &api.AssetConfigResponse{
+			StartDate: TestAssetConfig.StartDate,
 			Frequency: "PT1H",
 			RangeD:    "P2DT",
 		}

--- a/internal/api/response.go
+++ b/internal/api/response.go
@@ -32,8 +32,9 @@ type DLCDataResponse struct {
 
 // AssetConfigResponse represents the configuration of an asset api
 type AssetConfigResponse struct {
-	Frequency string `json:"frequency"`
-	RangeD    string `json:"range"`
+	StartDate time.Time `json:"startDate"`
+	Frequency string    `json:"frequency"`
+	RangeD    string    `json:"range"`
 }
 
 // OraclePublicKeyResponse represents the public key of the oracle

--- a/test/integration/api/asset/asset_api_test.go
+++ b/test/integration/api/asset/asset_api_test.go
@@ -62,6 +62,7 @@ func TestGetAssetConfig_WithValidAssets_ReturnsCorrectValue(t *testing.T) {
 			resp, err := req.Get(api.AssetBaseRoute + "/" + asset + api.RouteGETAssetConfig)
 			assert.NoError(t, err)
 			actual := resp.Result().(*api.AssetConfigResponse)
+			assert.Equal(t, expectedConfig.StartDate, actual.StartDate)
 			assert.Equal(t, iso8601.EncodeDuration(expectedConfig.Frequency), actual.Frequency)
 			assert.Equal(t, iso8601.EncodeDuration(expectedConfig.RangeD), actual.RangeD)
 		})


### PR DESCRIPTION
- add `startDate` as date iso in the api config response