### PR TITLE
Update to latest schnorr bip340

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG ARG_CFD_GO_VERSION=0.1.21
+ARG ARG_CFD_GO_VERSION=0.2.3
 ARG CFD_GO_ZIP=cfdgo-v${ARG_CFD_GO_VERSION}-alpine_x86_64.zip
 FROM golang:1.14-alpine as dev
 RUN apk update
@@ -13,7 +13,7 @@ ARG ARG_CFD_GO_VERSION
 ARG CFD_GO_ZIP
 ENV CFD_GO_VERSION=${ARG_CFD_GO_VERSION}
 RUN wget -O /${CFD_GO_ZIP} https://github.com/cryptogarageinc/cfd-go/releases/download/v${CFD_GO_VERSION}/${CFD_GO_ZIP} \
-     && unzip -q /${CFD_GO_ZIP} -d /
+    && unzip -q /${CFD_GO_ZIP} -d /
 
 COPY go.mod .
 COPY go.sum .

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/Bose/go-gin-logrus v1.0.3
-	github.com/cryptogarageinc/cfd-go v0.1.21
+	github.com/cryptogarageinc/cfd-go v0.2.3
 	github.com/cryptogarageinc/server-common-go v1.0.0
 	github.com/gin-gonic/gin v1.6.3
 	github.com/go-resty/resty/v2 v2.2.0
@@ -16,7 +16,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/stretchr/testify v1.4.0
+	github.com/stretchr/testify v1.6.1
 	golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37 // indirect
 	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a // indirect
 	gotest.tools/gotestsum v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
-github.com/cryptogarageinc/cfd-go v0.1.21 h1:Ju0RDcK0Tt/8AWCQ2zPNUjdsfLRbpXjVlggjGgJh3nY=
-github.com/cryptogarageinc/cfd-go v0.1.21/go.mod h1:9RAl7Mwh83eFeAR42/wlr5hTHkSyZY0yRN0bkyE/xqk=
+github.com/cryptogarageinc/cfd-go v0.2.3 h1:W89FOAA+tETj7PVCBu1SFn9iepfy/eA2aXTVGKdZFbU=
+github.com/cryptogarageinc/cfd-go v0.2.3/go.mod h1:pdFi8JhLm/LEr9pPuNGHbmDySWIj3mf8hBRicHtGNPQ=
 github.com/cryptogarageinc/server-common-go v1.0.0 h1:IYnABgBHKdl+yPef7xCYLrSeJxE6ZYcck5s+S5QWg74=
 github.com/cryptogarageinc/server-common-go v1.0.0/go.mod h1:4hmj8ZpR09fY0MRgX2w8p1y3YLraWEk4b+ILNIEq/vk=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -80,6 +80,7 @@ github.com/go-playground/validator/v10 v10.2.0 h1:KgJ0snyC2R9VXYN2rneOtQcw5aHQB1
 github.com/go-playground/validator/v10 v10.2.0/go.mod h1:uOYAAleCW8F/7oMFd6aG0GOhaH6EGOAJShg8Id5JGkI=
 github.com/go-resty/resty/v2 v2.2.0 h1:vgZ1cdblp8Aw4jZj3ZsKh6yKAlMg3CHMrqFSFFd+jgY=
 github.com/go-resty/resty/v2 v2.2.0/go.mod h1:nYW/8rxqQCmI3bPz9Fsmjbr2FBjGuR2Mzt6kDh3zZ7w=
+github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -111,6 +112,7 @@ github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXi
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.1.0 h1:Jf4mxPC/ziBnoPIdpQdPJ9OeiomAUHLvxmPRSPH9m4s=
 github.com/google/uuid v1.1.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -293,6 +295,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tebeka/strftime v0.1.5 h1:1NQKN1NiQgkqd/2moD6ySP/5CoZQsKa1d3ZhJ44Jpmg=
@@ -468,7 +472,11 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools/gotestsum v0.5.2 h1:sSKWtEFqorHhuBCHU6MeUl50cq9U2J3d1m5NlQTVrbY=
 gotest.tools/gotestsum v0.5.2/go.mod h1:hC9TQserDVTWcJuARh76Ydp3ZwuE+pIIWpt2BzDLD6M=
+gotest.tools/v3 v3.0.2 h1:kG1BFyqVHuQoVQiR1bWGnfz/fmHvvuiSPIV7rvl360E=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/internal/api/asset_controller.go
+++ b/internal/api/asset_controller.go
@@ -173,11 +173,7 @@ func findOrCreateDLCData(logger *logrus.Entry, db *gorm.DB, oracle dlccrypto.Cry
 	// if record is not found, need to create the record in db
 	if err != nil && gorm.IsRecordNotFoundError(err) {
 		logger.Debug("Generating new DLC data Rvalue")
-		signingK, err := oracle.GenerateKvalue()
-		if err != nil {
-			return nil, NewUnknownCryptoServiceError(err)
-		}
-		rvalue, err := oracle.ComputeRvalue(signingK)
+		signingK, rvalue, err := oracle.GenerateSchnorrKeyPair()
 		if err != nil {
 			return nil, NewUnknownCryptoServiceError(err)
 		}

--- a/internal/api/asset_controller_test.go
+++ b/internal/api/asset_controller_test.go
@@ -56,18 +56,18 @@ const datafeedValue = 100.06
 
 var TestResponseValues = &ResponseValue{
 	AssetID:   TestAsset.AssetID,
-	Kvalue:    "71957542da5ea5e6b58607a3e21f0eb4e871c785b5b3470fb5274213f050cd60",
-	Rvalue:    "02d7e8908aa101d0f7d3565fff11629d3b8fe0a7c431ad336e07de062df5053d6a",
+	Kvalue:    "d1e3dcdda619833ec2b91d4fd304e9be0ad85326c9f524dfbc53f443ab54063e",
+	Rvalue:    "44b1350439fc9a098db6edd5bd417eb1aeaa17ec60f9e5a799605feebd5c19eb",
 	Value:     fmt.Sprintf("%d", int(math.Round(datafeedValue))),
-	Signature: "26772fddf151463655823c906d1c01afb682b8c3533589fe71753a579bf59b22",
+	Signature: "44b1350439fc9a098db6edd5bd417eb1aeaa17ec60f9e5a799605feebd5c19ebf742bea67ff64f738c0426d04a22b30fe61258e074c0c90a1b13ce29d11f4b67",
 }
 
-func SetupMockValues() (*dlccrypto.PrivateKey, *dlccrypto.PublicKey, *dlccrypto.Signature, *float64, error) {
+func SetupMockValues() (*dlccrypto.PrivateKey, *dlccrypto.SchnorrPublicKey, *dlccrypto.Signature, *float64, error) {
 	kvalue, err := dlccrypto.NewPrivateKey(TestResponseValues.Kvalue)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
-	rvalue, err := dlccrypto.NewPublicKey(TestResponseValues.Rvalue)
+	rvalue, err := dlccrypto.NewSchnorrPublicKey(TestResponseValues.Rvalue)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
@@ -216,8 +216,7 @@ func TestAssetController_GetAssetRvalue_NotInDB_ReturnsCorrectValue(t *testing.T
 	}
 
 	crypto := mock_dlccrypto.NewMockCryptoService(ctrl)
-	crypto.EXPECT().GenerateKvalue().Return(kvalue, nil)
-	crypto.EXPECT().ComputeRvalue(kvalue).Return(rvalue, nil)
+	crypto.EXPECT().GenerateSchnorrKeyPair().Return(kvalue, rvalue, nil)
 
 	oracleService, err := NewTestOracleService()
 	if err != nil {
@@ -268,8 +267,7 @@ func TestAssetController_GetAssetSignature_NotInDB_ReturnsCorrectValue(t *testin
 		feed.EXPECT().FindPastAssetPrice("btc", "usd", expectedDate).Return(sigValue, nil)
 		// mock crypto
 		crypto := mock_dlccrypto.NewMockCryptoService(ctrl)
-		crypto.EXPECT().GenerateKvalue().Return(kvalue, nil)
-		crypto.EXPECT().ComputeRvalue(kvalue).Return(rvalue, nil)
+		crypto.EXPECT().GenerateSchnorrKeyPair().Return(kvalue, rvalue, nil)
 		crypto.EXPECT().ComputeSchnorrSignature(
 			oracleInstance.PrivateKey,
 			kvalue,

--- a/internal/api/oracle_controller_test.go
+++ b/internal/api/oracle_controller_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const OraclePrivateKey = "18E14A7B6A307F426A94F8114701E7C8E774E7F9A47E2C2035DB29A206321725"
-const OraclePublicKey = "0250863ad64a87ae8a2fe83c1af1a8403cb53f53e486d8511dad8a04887e5b2352"
+const OraclePrivateKey = "29cf848088781119018ba61f14b5328c9c299050e61abb9438cd77b81aacd73b"
+const OraclePublicKey = "c06fd4dee6502848b937840019effbab0856a227d984785367b079969471a6ed"
 
 func NewTestOracleService() (*oracle.Oracle, error) {
 	priv, err := dlccrypto.NewPrivateKey(OraclePrivateKey)

--- a/internal/api/response.go
+++ b/internal/api/response.go
@@ -8,7 +8,7 @@ import (
 
 // NewDLCDataResponse transforms a entity.DLCData to dlcData response
 func NewDLCDataResponse(
-	oraclePubKey *dlccrypto.PublicKey,
+	oraclePubKey *dlccrypto.SchnorrPublicKey,
 	dlcData *entity.DLCData) *DLCDataResponse {
 	return &DLCDataResponse{
 		OraclePublicKey: oraclePubKey.EncodeToString(),

--- a/internal/dlccrypto/bytestring_types.go
+++ b/internal/dlccrypto/bytestring_types.go
@@ -8,8 +8,8 @@ import (
 
 const (
 	sizePrivateKey = 32
-	sizePublicKey  = 33
-	sizeSignature  = 32
+	sizePublicKey  = 32
+	sizeSignature  = 64
 )
 
 // ErrInvalidBytestringSize represents a bytestring of wrong length for the struct type used
@@ -51,8 +51,8 @@ type PrivateKey struct {
 	ByteString
 }
 
-// NewPublicKey returns a new PublicKey instance
-func NewPublicKey(bytestring string) (*PublicKey, error) {
+// NewSchnorrPublicKey returns a new PublicKey instance
+func NewSchnorrPublicKey(bytestring string) (*SchnorrPublicKey, error) {
 	bt, err := NewByteString(bytestring)
 	if err != nil {
 		return nil, err
@@ -60,11 +60,11 @@ func NewPublicKey(bytestring string) (*PublicKey, error) {
 	if len(bt.bytes) != sizePublicKey {
 		return nil, invalidSizeError("PublicKey", sizePublicKey)
 	}
-	return &PublicKey{*bt}, nil
+	return &SchnorrPublicKey{*bt}, nil
 }
 
-// PublicKey represents a compressed public key
-type PublicKey struct {
+// SchnorrPublicKey represents a compressed public key
+type SchnorrPublicKey struct {
 	ByteString
 }
 

--- a/internal/dlccrypto/bytestring_types_test.go
+++ b/internal/dlccrypto/bytestring_types_test.go
@@ -10,13 +10,13 @@ import (
 const (
 	validBytestring = "abcdef0100"
 	validPrivateKey = "71957542da5ea5e6b58607a3e21f0eb4e871c785b5b3470fb5274213f050cd60"
-	validPublicKey  = "02d7e8908aa101d0f7d3565fff11629d3b8fe0a7c431ad336e07de062df5053d6a"
-	validSignature  = "60433d967d606c7ebd204d0f7d269bc435ea75d0fe3bb8b88bb102cde7972f00"
+	validPublicKey  = "d557c15ea53c46245be38a062e33c22c5880f6b776e36695befc6e28a3934bef"
+	validSignature  = "26ba8bc2e81388a1c75b3fa6de8a90ee3c45d35793c4e0327496c3d70b49f5a182931af82dd50ea6807cc4395715edc4c2af39c6c695c5a027d1fada0570bd6c"
 
 	invalidBytestring = "abcdefghrt65749"
 	invalidPrivateKey = "957542da5ea5e6b58607a3e21f0eb4e871c785b5b3470fb5274213f050cd60"
-	invalidPublicKey  = "d7e8908aa101d0f7d3565fff11629d3b8fe0a7c431ad336e07de062df5053d6a"
-	invalidSignature  = "433d967d606c7ebd204d0f7d269bc435ea75d0fe3bb8b88bb102cde7972f00"
+	invalidPublicKey  = "03d7e8908aa101d0f7d3565fff11629d3b8fe0a7c431ad336e07de062df5053d6a"
+	invalidSignature  = "26ba8bc2e81388a1c75b3fa6de8a90ee3c45d35793c4e0327496c3d70b49f5a182931af82dd50ea6807cc4395715edc4c2af39c6c695c5a027d1fada0570bd6ca"
 )
 
 func TestByteString_EncodeToString_ReturnsCorrectValue(t *testing.T) {
@@ -48,13 +48,13 @@ func TestNewPrivateKey_WithValidSizeBytestring_ReturnsNoError(t *testing.T) {
 }
 
 func TestNewPublicKey_WithInvalidSizeBytestring_ReturnsError(t *testing.T) {
-	bs, err := dlccrypto.NewPublicKey(invalidPublicKey)
+	bs, err := dlccrypto.NewSchnorrPublicKey(invalidPublicKey)
 	assert.Error(t, err)
 	assert.Nil(t, bs)
 }
 
 func TestNewPublicKey_WithValidSizeBytestring_ReturnsNoError(t *testing.T) {
-	_, err := dlccrypto.NewPublicKey(validPublicKey)
+	_, err := dlccrypto.NewSchnorrPublicKey(validPublicKey)
 	assert.NoError(t, err)
 }
 

--- a/internal/dlccrypto/cfdgo_crypto_service_test.go
+++ b/internal/dlccrypto/cfdgo_crypto_service_test.go
@@ -1,8 +1,10 @@
 package dlccrypto_test
 
 import (
+	"math/rand"
 	"p2pderivatives-oracle/internal/dlccrypto"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -24,26 +26,22 @@ type SignaturePair struct {
 }
 
 var (
-	TestOracleKeyPair = &KeyPair{PrivateKey: "18E14A7B6A307F426A94F8114701E7C8E774E7F9A47E2C2035DB29A206321725", PublicKey: "0250863ad64a87ae8a2fe83c1af1a8403cb53f53e486d8511dad8a04887e5b2352"}
+	TestOracleKeyPair = &KeyPair{PrivateKey: "18e14a7b6a307f426a94f8114701e7c8e774e7f9a47e2c2035db29a206321725", PublicKey: "50863ad64a87ae8a2fe83c1af1a8403cb53f53e486d8511dad8a04887e5b2352"}
 	TestKeyPairs      = [...]KeyPair{
-		{PrivateKey: "71957542da5ea5e6b58607a3e21f0eb4e871c785b5b3470fb5274213f050cd60", PublicKey: "02d7e8908aa101d0f7d3565fff11629d3b8fe0a7c431ad336e07de062df5053d6a"},
-		{PrivateKey: "a11ad4c96610096f956769cbd060e745750932c03fa30d1ea3b080428e12a336", PublicKey: "0226721aa761d4483df8105fb8ed2e1c6aa7cf309f5e1f0b48dcb615407697e193"},
-		{PrivateKey: "f912b67c2796be8fa70d55c5f240be799efa9908484af9bd43344bd95a62614b", PublicKey: "03bb3186cfae1a48d74a7ed0d6428226fbfac45bd5c6fc0d3f377f8c474e804735"},
-		{PrivateKey: "1ce5743c1d546ea501a421cd979581d62fd81fbd27e79b652ad2a273d45e92b5", PublicKey: "03b6e8ff7065ff02fb415542713b55b9c596cd7db908c2ecf782fcf29025b26943"},
-		{PrivateKey: "574ba4e483bce2581b11552fb301b0db7d549aa54d0a139f49ce14a3bb9fa107", PublicKey: "038b80e907786c8dc18921ac3ef7fc82e0e23a115da59dc630150bf49b5c970e7b"},
-		{PrivateKey: "224a8c4ce0fa3903b1d483625521cf1f46993bb8afcbf81a5b84ee94ce7d65de", PublicKey: "02325cfa2600ea6487e2467ce2c1efbc497e04b03f1fa02b8e9bd90146e8049381"},
-		{PrivateKey: "50617a8fc7d133e8c9ab31ff5eab79312c0f0a7b280d70c0e562eee3f05cc9c8", PublicKey: "03364591c8a6e01a79bc635af1fe331844c301e460e74b77cdab44227a57105a60"},
-		{PrivateKey: "ab0c1bd576e85d0c7817ef1f7c25684769ac10e71fadf618ee97f003aa1b14ff", PublicKey: "02d83ca02cdce6d8e934fdcd8a3bc5f874182de950db732184ccde01d77994a58b"},
+		{PrivateKey: "dcfbf4fc4f357ac42e038c00dc8a9d4f51f04b5ef7b31ce413b6daad5b9efb69", PublicKey: "2b4ec6a8dff179be54a40e68ba48c2f81a239aaf1dae5b625a371c52dca7e649"},
+		{PrivateKey: "b3b2b54604efa25ad90f04c51a70a415fdb246253cb74f7cce3918ed54f24df1", PublicKey: "fcc2004734a187853e98b62a7715bcf63c44bd8bc3ade6e9c518fe34f1602a22"},
+		{PrivateKey: "4cb24cab7de4b95e1d37164dd1583a720f366b1801549a0e90aceea988932ce6", PublicKey: "c900116a6219b8f24dde0e7828e73b2258cd7fc9475192d013f30cd69c1666c6"},
+		{PrivateKey: "9607eaacb30a1b2e84ea3b15130b7448be2cfcaf882be229da254d3dcd46b7f0", PublicKey: "50f88b6346375cc847526c57962368cc9ba2f0d26404a0f38c09b122b31488ef"},
+		{PrivateKey: "cf7d4800d89f4673d87a97f4a16b02f1890e673ab57c5c3c31c1b01ff0df13d0", PublicKey: "c38ddcd58cede91f22488be1b5ab07b4ca3c84bf8dc94c0712d911aa5030bd20"},
+		{PrivateKey: "abf4c668af6c9fa8c15edc9a996e35d8fbb3feed69259f0e875946e8e37621c9", PublicKey: "9599d5293b3ef1eed597234a0af94190e11e692d02ff91cc3648dd9debfe8637"},
 	}
 	TestKRValues = [...]RKPair{
-		{k: "71957542da5ea5e6b58607a3e21f0eb4e871c785b5b3470fb5274213f050cd60", rvalue: "02d7e8908aa101d0f7d3565fff11629d3b8fe0a7c431ad336e07de062df5053d6a"},
-		{k: "a11ad4c96610096f956769cbd060e745750932c03fa30d1ea3b080428e12a336", rvalue: "0226721aa761d4483df8105fb8ed2e1c6aa7cf309f5e1f0b48dcb615407697e193"},
-		{k: "f912b67c2796be8fa70d55c5f240be799efa9908484af9bd43344bd95a62614b", rvalue: "02bb3186cfae1a48d74a7ed0d6428226fbfac45bd5c6fc0d3f377f8c474e804735"},
-		{k: "1ce5743c1d546ea501a421cd979581d62fd81fbd27e79b652ad2a273d45e92b5", rvalue: "02b6e8ff7065ff02fb415542713b55b9c596cd7db908c2ecf782fcf29025b26943"},
-		{k: "574ba4e483bce2581b11552fb301b0db7d549aa54d0a139f49ce14a3bb9fa107", rvalue: "028b80e907786c8dc18921ac3ef7fc82e0e23a115da59dc630150bf49b5c970e7b"},
-		{k: "224a8c4ce0fa3903b1d483625521cf1f46993bb8afcbf81a5b84ee94ce7d65de", rvalue: "02325cfa2600ea6487e2467ce2c1efbc497e04b03f1fa02b8e9bd90146e8049381"},
-		{k: "50617a8fc7d133e8c9ab31ff5eab79312c0f0a7b280d70c0e562eee3f05cc9c8", rvalue: "02364591c8a6e01a79bc635af1fe331844c301e460e74b77cdab44227a57105a60"},
-		{k: "ab0c1bd576e85d0c7817ef1f7c25684769ac10e71fadf618ee97f003aa1b14ff", rvalue: "02d83ca02cdce6d8e934fdcd8a3bc5f874182de950db732184ccde01d77994a58b"},
+		{k: "d8667a07d8a66cbdeda3a8da8c8ce802bf22493abea287df37f92ee0d7725fb0", rvalue: "5a00f102a9a2c789046da82a900b4b1b34fcf73dce5ac1063a653c2bf9b3f5f0"},
+		{k: "2644083242f5cf7ff89331f219cb064ee81f6279face75d96ea5a22b2180fa72", rvalue: "d34fba30e1d6f8e82e37ae34ded1f16aac0e1527257201bbb21025ea49c9bdea"},
+		{k: "7db3f7091798d2d426205bdb194f74401014755e3e58f9303390c1ff0e4bd44a", rvalue: "1fc82267e136cb89bd2ac0c2b0c7e3ef202d895193f071556bd91769bd45c752"},
+		{k: "82b12720e1ee86ef2c2fb29726026357438b509e00cada4bd368c110e30f0540", rvalue: "8edc285addfcf2b3d3868a419cca4aeb89dff72e966be63dd57dac59a9c7c6df"},
+		{k: "b80916acc3c31ddb05b72526fff1b7d813a55dd84616635fe2907e1a36755f75", rvalue: "6b02fb3fdaf0a9e6d05e4d1973a56ce7a4f2e44e02a6c4a0574f372d7771a9f3"},
+		{k: "f8f6f58f646202749081862693763b48b740964597c2ea641b267aeb9fbecf4d", rvalue: "1ef3179d5bb5ded119de7c63d3e2abf6aea94b5fd4458ad9b46dd8f59df2ccf5"},
 	}
 	TestMessage = [...]string{
 		"1200",
@@ -55,11 +53,12 @@ var (
 	}
 
 	TestSignature = [...]SignaturePair{
-		{krPair: TestKRValues[0], message: TestMessage[0], signature: "26772fddf151463655823c906d1c01afb682b8c3533589fe71753a579bf59b22"},
-		{krPair: TestKRValues[1], message: TestMessage[0], signature: "61724003ecdf295d220c481f87a7905399af05671a0c4acd2979efaad778cf5a"},
-		{krPair: TestKRValues[2], message: TestMessage[1], signature: "60433d967d606c7ebd204d0f7d269bc435ea75d0fe3bb8b88bb102cde7972f00"},
-		{krPair: TestKRValues[3], message: TestMessage[1], signature: "0ad1c72b5abbdcb311bd878b960847e53808cfb8cb2bf3ae03eff74d3058028c"},
-		{krPair: TestKRValues[4], message: TestMessage[2], signature: "5f7e28241fbdc768f8a541f523c88887c133751acab2ef7a580e636abff0f85b"},
+		{krPair: TestKRValues[0], message: TestMessage[0], signature: "5a00f102a9a2c789046da82a900b4b1b34fcf73dce5ac1063a653c2bf9b3f5f0c50e5b475b7fefc5deac176a91fde56e1fa8c522661af2e6a6ea60b3f3e4d82e"},
+		{krPair: TestKRValues[1], message: TestMessage[1], signature: "d34fba30e1d6f8e82e37ae34ded1f16aac0e1527257201bbb21025ea49c9bdea536c4b9fceeed308bf06d6b4e006555adc481b1e93995a599b1b98f1ac66b195"},
+		{krPair: TestKRValues[2], message: TestMessage[2], signature: "1fc82267e136cb89bd2ac0c2b0c7e3ef202d895193f071556bd91769bd45c752d69f9d53fdb1a7fb280d718a8bf083cbb5a796c0021fdde34e3280b63d109e6a"},
+		{krPair: TestKRValues[3], message: TestMessage[3], signature: "8edc285addfcf2b3d3868a419cca4aeb89dff72e966be63dd57dac59a9c7c6dfa56233133551e0f1bb7693490eba8e2b41caa0d33ace97bc7598d26b659980f6"},
+		{krPair: TestKRValues[4], message: TestMessage[4], signature: "6b02fb3fdaf0a9e6d05e4d1973a56ce7a4f2e44e02a6c4a0574f372d7771a9f365af59c67f1460b0090bf2357c6c387fc67f45f7b7e07cb8e65172d7898dee4a"},
+		{krPair: TestKRValues[5], message: TestMessage[5], signature: "1ef3179d5bb5ded119de7c63d3e2abf6aea94b5fd4458ad9b46dd8f59df2ccf548c13c2c6e9d2aab66ea8f393d29bc9f658ff56c629528ab6e80370c92b5afec"},
 	}
 )
 
@@ -67,34 +66,42 @@ func NewTestCfdgoCryptoService() dlccrypto.CryptoService {
 	return dlccrypto.NewCfdgoCryptoService()
 }
 
+const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+func RandString(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letterBytes[rand.Intn(len(letterBytes))]
+	}
+	return string(b)
+}
+
 func Test_CfdgoCryptoService_PublicKeyFromPrivateKey(t *testing.T) {
 	crypto := NewTestCfdgoCryptoService()
 	for _, keypair := range TestKeyPairs {
 		privKey, err := dlccrypto.NewPrivateKey(keypair.PrivateKey)
 		assert.NoError(t, err)
-		pubkey, err := crypto.PublicKeyFromPrivateKey(privKey)
+		pubkey, err := crypto.SchnorrPublicKeyFromPrivateKey(privKey)
 		assert.NoError(t, err)
 		assert.Equal(t, keypair.PublicKey, pubkey.EncodeToString())
 	}
 }
 
-func Test_CfdgoCryptoService_GenerateKvalue(t *testing.T) {
-	crypto := dlccrypto.NewCfdgoCryptoService()
-	k1, err1 := crypto.GenerateKvalue()
-	assert.NoError(t, err1)
-	k2, err2 := crypto.GenerateKvalue()
-	assert.NoError(t, err2)
-	assert.NotEqual(t, k1.EncodeToString(), k2.EncodeToString())
-}
+func Test_SignAndVerify(t *testing.T) {
+	crypto := NewTestCfdgoCryptoService()
+	privkey, pubkey, _ := crypto.GenerateSchnorrKeyPair()
+	seed := time.Now().UnixNano()
+	t.Log("Seed: ", seed)
+	rand.Seed(seed)
 
-func Test_CfdgoCryptoService_ComputeRvalue(t *testing.T) {
-	crypto := dlccrypto.NewCfdgoCryptoService()
-	for _, rk := range TestKRValues {
-		privKey, err := dlccrypto.NewPrivateKey(rk.k)
+	for i := 0; i < 100; i++ {
+		msg := RandString(10)
+		kvalue, _, _ := crypto.GenerateSchnorrKeyPair()
+		sig, err := crypto.ComputeSchnorrSignature(privkey, kvalue, msg)
 		assert.NoError(t, err)
-		rvalue, err := crypto.ComputeRvalue(privKey)
+		valid, err := crypto.VerifySchnorrSignature(pubkey, sig, msg)
 		assert.NoError(t, err)
-		assert.Equal(t, rk.rvalue, rvalue.EncodeToString())
+		assert.True(t, valid)
 	}
 }
 
@@ -113,14 +120,13 @@ func Test_CfdgoCryptoService_ComputeSchnorrSignature(t *testing.T) {
 
 func Test_CfdgoCryptoService_VerifySignature(t *testing.T) {
 	crypto := dlccrypto.NewCfdgoCryptoService()
-	oraclePub, err := dlccrypto.NewPublicKey(TestOracleKeyPair.PublicKey)
+	oraclePub, err := dlccrypto.NewSchnorrPublicKey(TestOracleKeyPair.PublicKey)
 	assert.NoError(t, err)
 	for _, sigpair := range TestSignature {
-		rvalue, err := dlccrypto.NewPublicKey(sigpair.krPair.rvalue)
 		assert.NoError(t, err)
 		sig, err := dlccrypto.NewSignature(sigpair.signature)
 		assert.NoError(t, err)
-		check, err := crypto.VerifySchnorrSignature(oraclePub, rvalue, sig, sigpair.message)
+		check, err := crypto.VerifySchnorrSignature(oraclePub, sig, sigpair.message)
 		assert.NoError(t, err)
 		assert.True(t, check)
 	}

--- a/internal/dlccrypto/crypto_service.go
+++ b/internal/dlccrypto/crypto_service.go
@@ -2,9 +2,8 @@ package dlccrypto
 
 // CryptoService interface for an utility crypto service
 type CryptoService interface {
-	GenerateKvalue() (*PrivateKey, error)
-	ComputeRvalue(nonce *PrivateKey) (*PublicKey, error)
-	PublicKeyFromPrivateKey(privateKey *PrivateKey) (*PublicKey, error)
+	GenerateSchnorrKeyPair() (*PrivateKey, *SchnorrPublicKey, error)
+	SchnorrPublicKeyFromPrivateKey(privateKey *PrivateKey) (*SchnorrPublicKey, error)
 	ComputeSchnorrSignature(privateKey *PrivateKey, oneTimeSigningK *PrivateKey, message string) (*Signature, error)
-	VerifySchnorrSignature(publicKey *PublicKey, rvalue *PublicKey, signature *Signature, message string) (bool, error)
+	VerifySchnorrSignature(publicKey *SchnorrPublicKey, signature *Signature, message string) (bool, error)
 }

--- a/internal/oracle/oracle.go
+++ b/internal/oracle/oracle.go
@@ -10,14 +10,14 @@ import (
 // Oracle represents an oracle with private key, public key pair
 type Oracle struct {
 	PrivateKey *dlccrypto.PrivateKey
-	PublicKey  *dlccrypto.PublicKey
+	PublicKey  *dlccrypto.SchnorrPublicKey
 }
 
 // New returns a new Oracle instance
 // the public key will be calculated from the private key
 func New(privateKey *dlccrypto.PrivateKey) (*Oracle, error) {
 	cryptoService := dlccrypto.NewCfdgoCryptoService()
-	publicKey, err := cryptoService.PublicKeyFromPrivateKey(privateKey)
+	publicKey, err := cryptoService.SchnorrPublicKeyFromPrivateKey(privateKey)
 	if err != nil {
 		return nil, errors.WithMessage(err, "Could not recover Oracle Public Key")
 	}

--- a/internal/oracle/oracle_test.go
+++ b/internal/oracle/oracle_test.go
@@ -18,7 +18,7 @@ var ExpectedKeyPair = struct {
 	passPath   string
 }{
 	privateKey: "c85c333c73eb6daf3479d0236b261d7512cb5daf6955beea5d66a180d34260ae",
-	publicKey:  "03d557c15ea53c46245be38a062e33c22c5880f6b776e36695befc6e28a3934bef",
+	publicKey:  "d557c15ea53c46245be38a062e33c22c5880f6b776e36695befc6e28a3934bef",
 	password:   "XqH/LtBBrBJ/iSSxx5gejDAwA3nbiIGBV0w/SqGnPXc=",
 	keyPath:    filepath.Join(test.VectorsDirectoryPath, "oracle/key.pem"),
 	passPath:   filepath.Join(test.VectorsDirectoryPath, "oracle/pass.txt"),

--- a/test/mock/datafeed/mock_datafeed.go
+++ b/test/mock/datafeed/mock_datafeed.go
@@ -10,30 +10,30 @@ import (
 	time "time"
 )
 
-// MockDataFeed is a mock of DataFeed interface
+// MockDataFeed is a mock of DataFeed interface.
 type MockDataFeed struct {
 	ctrl     *gomock.Controller
 	recorder *MockDataFeedMockRecorder
 }
 
-// MockDataFeedMockRecorder is the mock recorder for MockDataFeed
+// MockDataFeedMockRecorder is the mock recorder for MockDataFeed.
 type MockDataFeedMockRecorder struct {
 	mock *MockDataFeed
 }
 
-// NewMockDataFeed creates a new mock instance
+// NewMockDataFeed creates a new mock instance.
 func NewMockDataFeed(ctrl *gomock.Controller) *MockDataFeed {
 	mock := &MockDataFeed{ctrl: ctrl}
 	mock.recorder = &MockDataFeedMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockDataFeed) EXPECT() *MockDataFeedMockRecorder {
 	return m.recorder
 }
 
-// FindCurrentAssetPrice mocks base method
+// FindCurrentAssetPrice mocks base method.
 func (m *MockDataFeed) FindCurrentAssetPrice(assetID, currency string) (*float64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FindCurrentAssetPrice", assetID, currency)
@@ -42,13 +42,13 @@ func (m *MockDataFeed) FindCurrentAssetPrice(assetID, currency string) (*float64
 	return ret0, ret1
 }
 
-// FindCurrentAssetPrice indicates an expected call of FindCurrentAssetPrice
+// FindCurrentAssetPrice indicates an expected call of FindCurrentAssetPrice.
 func (mr *MockDataFeedMockRecorder) FindCurrentAssetPrice(assetID, currency interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindCurrentAssetPrice", reflect.TypeOf((*MockDataFeed)(nil).FindCurrentAssetPrice), assetID, currency)
 }
 
-// FindPastAssetPrice mocks base method
+// FindPastAssetPrice mocks base method.
 func (m *MockDataFeed) FindPastAssetPrice(assetID, currency string, date time.Time) (*float64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FindPastAssetPrice", assetID, currency, date)
@@ -57,36 +57,36 @@ func (m *MockDataFeed) FindPastAssetPrice(assetID, currency string, date time.Ti
 	return ret0, ret1
 }
 
-// FindPastAssetPrice indicates an expected call of FindPastAssetPrice
+// FindPastAssetPrice indicates an expected call of FindPastAssetPrice.
 func (mr *MockDataFeedMockRecorder) FindPastAssetPrice(assetID, currency, date interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindPastAssetPrice", reflect.TypeOf((*MockDataFeed)(nil).FindPastAssetPrice), assetID, currency, date)
 }
 
-// MockAssetPriceFeed is a mock of AssetPriceFeed interface
+// MockAssetPriceFeed is a mock of AssetPriceFeed interface.
 type MockAssetPriceFeed struct {
 	ctrl     *gomock.Controller
 	recorder *MockAssetPriceFeedMockRecorder
 }
 
-// MockAssetPriceFeedMockRecorder is the mock recorder for MockAssetPriceFeed
+// MockAssetPriceFeedMockRecorder is the mock recorder for MockAssetPriceFeed.
 type MockAssetPriceFeedMockRecorder struct {
 	mock *MockAssetPriceFeed
 }
 
-// NewMockAssetPriceFeed creates a new mock instance
+// NewMockAssetPriceFeed creates a new mock instance.
 func NewMockAssetPriceFeed(ctrl *gomock.Controller) *MockAssetPriceFeed {
 	mock := &MockAssetPriceFeed{ctrl: ctrl}
 	mock.recorder = &MockAssetPriceFeedMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockAssetPriceFeed) EXPECT() *MockAssetPriceFeedMockRecorder {
 	return m.recorder
 }
 
-// FindCurrentAssetPrice mocks base method
+// FindCurrentAssetPrice mocks base method.
 func (m *MockAssetPriceFeed) FindCurrentAssetPrice(assetID, currency string) (*float64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FindCurrentAssetPrice", assetID, currency)
@@ -95,13 +95,13 @@ func (m *MockAssetPriceFeed) FindCurrentAssetPrice(assetID, currency string) (*f
 	return ret0, ret1
 }
 
-// FindCurrentAssetPrice indicates an expected call of FindCurrentAssetPrice
+// FindCurrentAssetPrice indicates an expected call of FindCurrentAssetPrice.
 func (mr *MockAssetPriceFeedMockRecorder) FindCurrentAssetPrice(assetID, currency interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindCurrentAssetPrice", reflect.TypeOf((*MockAssetPriceFeed)(nil).FindCurrentAssetPrice), assetID, currency)
 }
 
-// FindPastAssetPrice mocks base method
+// FindPastAssetPrice mocks base method.
 func (m *MockAssetPriceFeed) FindPastAssetPrice(assetID, currency string, date time.Time) (*float64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FindPastAssetPrice", assetID, currency, date)
@@ -110,7 +110,7 @@ func (m *MockAssetPriceFeed) FindPastAssetPrice(assetID, currency string, date t
 	return ret0, ret1
 }
 
-// FindPastAssetPrice indicates an expected call of FindPastAssetPrice
+// FindPastAssetPrice indicates an expected call of FindPastAssetPrice.
 func (mr *MockAssetPriceFeedMockRecorder) FindPastAssetPrice(assetID, currency, date interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindPastAssetPrice", reflect.TypeOf((*MockAssetPriceFeed)(nil).FindPastAssetPrice), assetID, currency, date)

--- a/test/mock/dlccrypto/mock_crypto_service.go
+++ b/test/mock/dlccrypto/mock_crypto_service.go
@@ -10,75 +10,61 @@ import (
 	reflect "reflect"
 )
 
-// MockCryptoService is a mock of CryptoService interface
+// MockCryptoService is a mock of CryptoService interface.
 type MockCryptoService struct {
 	ctrl     *gomock.Controller
 	recorder *MockCryptoServiceMockRecorder
 }
 
-// MockCryptoServiceMockRecorder is the mock recorder for MockCryptoService
+// MockCryptoServiceMockRecorder is the mock recorder for MockCryptoService.
 type MockCryptoServiceMockRecorder struct {
 	mock *MockCryptoService
 }
 
-// NewMockCryptoService creates a new mock instance
+// NewMockCryptoService creates a new mock instance.
 func NewMockCryptoService(ctrl *gomock.Controller) *MockCryptoService {
 	mock := &MockCryptoService{ctrl: ctrl}
 	mock.recorder = &MockCryptoServiceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockCryptoService) EXPECT() *MockCryptoServiceMockRecorder {
 	return m.recorder
 }
 
-// GenerateKvalue mocks base method
-func (m *MockCryptoService) GenerateKvalue() (*dlccrypto.PrivateKey, error) {
+// GenerateSchnorrKeyPair mocks base method.
+func (m *MockCryptoService) GenerateSchnorrKeyPair() (*dlccrypto.PrivateKey, *dlccrypto.SchnorrPublicKey, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GenerateKvalue")
+	ret := m.ctrl.Call(m, "GenerateSchnorrKeyPair")
 	ret0, _ := ret[0].(*dlccrypto.PrivateKey)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(*dlccrypto.SchnorrPublicKey)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
-// GenerateKvalue indicates an expected call of GenerateKvalue
-func (mr *MockCryptoServiceMockRecorder) GenerateKvalue() *gomock.Call {
+// GenerateSchnorrKeyPair indicates an expected call of GenerateSchnorrKeyPair.
+func (mr *MockCryptoServiceMockRecorder) GenerateSchnorrKeyPair() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateKvalue", reflect.TypeOf((*MockCryptoService)(nil).GenerateKvalue))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateSchnorrKeyPair", reflect.TypeOf((*MockCryptoService)(nil).GenerateSchnorrKeyPair))
 }
 
-// ComputeRvalue mocks base method
-func (m *MockCryptoService) ComputeRvalue(nonce *dlccrypto.PrivateKey) (*dlccrypto.PublicKey, error) {
+// SchnorrPublicKeyFromPrivateKey mocks base method.
+func (m *MockCryptoService) SchnorrPublicKeyFromPrivateKey(privateKey *dlccrypto.PrivateKey) (*dlccrypto.SchnorrPublicKey, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ComputeRvalue", nonce)
-	ret0, _ := ret[0].(*dlccrypto.PublicKey)
+	ret := m.ctrl.Call(m, "SchnorrPublicKeyFromPrivateKey", privateKey)
+	ret0, _ := ret[0].(*dlccrypto.SchnorrPublicKey)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ComputeRvalue indicates an expected call of ComputeRvalue
-func (mr *MockCryptoServiceMockRecorder) ComputeRvalue(nonce interface{}) *gomock.Call {
+// SchnorrPublicKeyFromPrivateKey indicates an expected call of SchnorrPublicKeyFromPrivateKey.
+func (mr *MockCryptoServiceMockRecorder) SchnorrPublicKeyFromPrivateKey(privateKey interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ComputeRvalue", reflect.TypeOf((*MockCryptoService)(nil).ComputeRvalue), nonce)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SchnorrPublicKeyFromPrivateKey", reflect.TypeOf((*MockCryptoService)(nil).SchnorrPublicKeyFromPrivateKey), privateKey)
 }
 
-// PublicKeyFromPrivateKey mocks base method
-func (m *MockCryptoService) PublicKeyFromPrivateKey(privateKey *dlccrypto.PrivateKey) (*dlccrypto.PublicKey, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PublicKeyFromPrivateKey", privateKey)
-	ret0, _ := ret[0].(*dlccrypto.PublicKey)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// PublicKeyFromPrivateKey indicates an expected call of PublicKeyFromPrivateKey
-func (mr *MockCryptoServiceMockRecorder) PublicKeyFromPrivateKey(privateKey interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublicKeyFromPrivateKey", reflect.TypeOf((*MockCryptoService)(nil).PublicKeyFromPrivateKey), privateKey)
-}
-
-// ComputeSchnorrSignature mocks base method
+// ComputeSchnorrSignature mocks base method.
 func (m *MockCryptoService) ComputeSchnorrSignature(privateKey, oneTimeSigningK *dlccrypto.PrivateKey, message string) (*dlccrypto.Signature, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ComputeSchnorrSignature", privateKey, oneTimeSigningK, message)
@@ -87,23 +73,23 @@ func (m *MockCryptoService) ComputeSchnorrSignature(privateKey, oneTimeSigningK 
 	return ret0, ret1
 }
 
-// ComputeSchnorrSignature indicates an expected call of ComputeSchnorrSignature
+// ComputeSchnorrSignature indicates an expected call of ComputeSchnorrSignature.
 func (mr *MockCryptoServiceMockRecorder) ComputeSchnorrSignature(privateKey, oneTimeSigningK, message interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ComputeSchnorrSignature", reflect.TypeOf((*MockCryptoService)(nil).ComputeSchnorrSignature), privateKey, oneTimeSigningK, message)
 }
 
-// VerifySchnorrSignature mocks base method
-func (m *MockCryptoService) VerifySchnorrSignature(publicKey, rvalue *dlccrypto.PublicKey, signature *dlccrypto.Signature, message string) (bool, error) {
+// VerifySchnorrSignature mocks base method.
+func (m *MockCryptoService) VerifySchnorrSignature(publicKey *dlccrypto.SchnorrPublicKey, signature *dlccrypto.Signature, message string) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "VerifySchnorrSignature", publicKey, rvalue, signature, message)
+	ret := m.ctrl.Call(m, "VerifySchnorrSignature", publicKey, signature, message)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// VerifySchnorrSignature indicates an expected call of VerifySchnorrSignature
-func (mr *MockCryptoServiceMockRecorder) VerifySchnorrSignature(publicKey, rvalue, signature, message interface{}) *gomock.Call {
+// VerifySchnorrSignature indicates an expected call of VerifySchnorrSignature.
+func (mr *MockCryptoServiceMockRecorder) VerifySchnorrSignature(publicKey, signature, message interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifySchnorrSignature", reflect.TypeOf((*MockCryptoService)(nil).VerifySchnorrSignature), publicKey, rvalue, signature, message)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifySchnorrSignature", reflect.TypeOf((*MockCryptoService)(nil).VerifySchnorrSignature), publicKey, signature, message)
 }


### PR DESCRIPTION
Update to cfd-go to use the latest bip340 specifications for Schnorr signatures.