### PR TITLE
Refactor cfddgo in separate module

### DIFF
--- a/cmd/p2pdoracle/main.go
+++ b/cmd/p2pdoracle/main.go
@@ -3,22 +3,23 @@ package main
 import (
 	"context"
 	"flag"
-	conf "github.com/cryptogarageinc/server-common-go/pkg/configuration"
-	"github.com/cryptogarageinc/server-common-go/pkg/database/orm"
-	"github.com/cryptogarageinc/server-common-go/pkg/log"
-	"github.com/cryptogarageinc/server-common-go/pkg/rest/router"
 	stdlog "log"
 	"net/http"
 	"os"
 	"os/signal"
 	"p2pderivatives-oracle/internal/api"
+	"p2pderivatives-oracle/internal/cfddlccrypto"
 	"p2pderivatives-oracle/internal/cryptocompare"
 	"p2pderivatives-oracle/internal/database/entity"
 	"p2pderivatives-oracle/internal/datafeed"
-	"p2pderivatives-oracle/internal/dlccrypto"
 	"p2pderivatives-oracle/internal/oracle"
 	"syscall"
 	"time"
+
+	conf "github.com/cryptogarageinc/server-common-go/pkg/configuration"
+	"github.com/cryptogarageinc/server-common-go/pkg/database/orm"
+	"github.com/cryptogarageinc/server-common-go/pkg/log"
+	"github.com/cryptogarageinc/server-common-go/pkg/rest/router"
 )
 
 var (
@@ -166,12 +167,12 @@ func newInitializedRouter(log *log.Log, config *conf.Configuration) *router.Rout
 // NewDefaultOracleAPI returns a router.API with default crypto, database and datafeed services
 func NewDefaultOracleAPI(l *log.Log, config *conf.Configuration) router.API {
 	// Setup crypto service
-	cryptoInstance := dlccrypto.NewCfdgoCryptoService()
+	cryptoInstance := cfddlccrypto.NewCfdgoCryptoService()
 
 	// Setup Oracle
 	oracleConfig := &oracle.Config{}
 	config.InitializeComponentConfig(oracleConfig)
-	oracleInstance, err := oracle.FromConfig(oracleConfig)
+	oracleInstance, err := oracle.FromConfig(oracleConfig, cryptoInstance)
 	if err != nil {
 		l.Logger.Fatalf("Could not create a oracle instance")
 		panic(err)

--- a/internal/api/oracle_controller_test.go
+++ b/internal/api/oracle_controller_test.go
@@ -22,7 +22,11 @@ func NewTestOracleService() (*oracle.Oracle, error) {
 	if err != nil {
 		return nil, err
 	}
-	return oracle.New(priv)
+	pub, err := dlccrypto.NewSchnorrPublicKey(OraclePublicKey)
+	if err != nil {
+		return nil, err
+	}
+	return oracle.New(priv, pub), nil
 }
 
 func SetupOracleEngine(recorder *httptest.ResponseRecorder, o *oracle.Oracle) (*gin.Context, *gin.Engine) {

--- a/internal/cfddlccrypto/cfdgo_crypto_service_test.go
+++ b/internal/cfddlccrypto/cfdgo_crypto_service_test.go
@@ -1,7 +1,8 @@
-package dlccrypto_test
+package cfddlccrypto_test
 
 import (
 	"math/rand"
+	"p2pderivatives-oracle/internal/cfddlccrypto"
 	"p2pderivatives-oracle/internal/dlccrypto"
 	"testing"
 	"time"
@@ -63,7 +64,7 @@ var (
 )
 
 func NewTestCfdgoCryptoService() dlccrypto.CryptoService {
-	return dlccrypto.NewCfdgoCryptoService()
+	return cfddlccrypto.NewCfdgoCryptoService()
 }
 
 const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -106,7 +107,7 @@ func Test_SignAndVerify(t *testing.T) {
 }
 
 func Test_CfdgoCryptoService_ComputeSchnorrSignature(t *testing.T) {
-	crypto := dlccrypto.NewCfdgoCryptoService()
+	crypto := cfddlccrypto.NewCfdgoCryptoService()
 	oracleKey, err := dlccrypto.NewPrivateKey(TestOracleKeyPair.PrivateKey)
 	assert.NoError(t, err)
 	for _, sigpair := range TestSignature {
@@ -119,7 +120,7 @@ func Test_CfdgoCryptoService_ComputeSchnorrSignature(t *testing.T) {
 }
 
 func Test_CfdgoCryptoService_VerifySignature(t *testing.T) {
-	crypto := dlccrypto.NewCfdgoCryptoService()
+	crypto := cfddlccrypto.NewCfdgoCryptoService()
 	oraclePub, err := dlccrypto.NewSchnorrPublicKey(TestOracleKeyPair.PublicKey)
 	assert.NoError(t, err)
 	for _, sigpair := range TestSignature {

--- a/internal/oracle/oracle_test.go
+++ b/internal/oracle/oracle_test.go
@@ -1,7 +1,7 @@
 package oracle_test
 
 import (
-	"p2pderivatives-oracle/internal/dlccrypto"
+	"p2pderivatives-oracle/internal/cfddlccrypto"
 	"p2pderivatives-oracle/internal/oracle"
 	"p2pderivatives-oracle/test"
 	"path/filepath"
@@ -24,19 +24,13 @@ var ExpectedKeyPair = struct {
 	passPath:   filepath.Join(test.VectorsDirectoryPath, "oracle/pass.txt"),
 }
 
-func Test_New_WithInValidKey_ReturnsError(t *testing.T) {
-	invalidPrivKey := &dlccrypto.PrivateKey{}
-	_, err := oracle.New(invalidPrivKey)
-	assert.NotNil(t, err)
-}
-
 func Test_FromConfig_WithPass_ReturnsOracle(t *testing.T) {
 	config := &oracle.Config{
 		KeyFile: ExpectedKeyPair.keyPath,
 		KeyPass: ExpectedKeyPair.password,
 	}
 
-	oracleInstance, err := oracle.FromConfig(config)
+	oracleInstance, err := oracle.FromConfig(config, cfddlccrypto.NewCfdgoCryptoService())
 	assert.NoError(t, err)
 	if assert.NotNil(t, oracleInstance) {
 		assert.Equal(t, ExpectedKeyPair.privateKey, oracleInstance.PrivateKey.EncodeToString())
@@ -49,7 +43,7 @@ func Test_FromConfig_WithPassFile_ReturnsOracle(t *testing.T) {
 		KeyFile:     ExpectedKeyPair.keyPath,
 		KeyPassFile: ExpectedKeyPair.passPath,
 	}
-	oracleInstance, err := oracle.FromConfig(config)
+	oracleInstance, err := oracle.FromConfig(config, cfddlccrypto.NewCfdgoCryptoService())
 	assert.NoError(t, err)
 	if assert.NotNil(t, oracleInstance) {
 		assert.Equal(t, ExpectedKeyPair.privateKey, oracleInstance.PrivateKey.EncodeToString())
@@ -61,6 +55,6 @@ func Test_FromConfig_WithNoPass_ReturnsError(t *testing.T) {
 	config := &oracle.Config{
 		KeyFile: ExpectedKeyPair.keyPath,
 	}
-	_, err := oracle.FromConfig(config)
+	_, err := oracle.FromConfig(config, cfddlccrypto.NewCfdgoCryptoService())
 	assert.NotNil(t, err)
 }

--- a/test/integration/api/asset/asset_api_test.go
+++ b/test/integration/api/asset/asset_api_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"p2pderivatives-oracle/internal/api"
+	"p2pderivatives-oracle/internal/cfddlccrypto"
 	"p2pderivatives-oracle/internal/dlccrypto"
 	helper "p2pderivatives-oracle/test/integration"
 	"testing"
@@ -194,7 +195,7 @@ func assertPublishedDate(
 func assertSignature(assertSub *assert.Assertions, rvalueHex string, sigHex string, message string) bool {
 	sig, err := dlccrypto.NewSignature(sigHex)
 	assertSub.NoError(err)
-	isValidSignature, err := dlccrypto.NewCfdgoCryptoService().VerifySchnorrSignature(
+	isValidSignature, err := cfddlccrypto.NewCfdgoCryptoService().VerifySchnorrSignature(
 		helper.ExpectedOracle.PublicKey,
 		sig,
 		message)

--- a/test/integration/helper.go
+++ b/test/integration/helper.go
@@ -8,10 +8,12 @@ import (
 	"log"
 	"os"
 	"p2pderivatives-oracle/internal/api"
-	conf "github.com/cryptogarageinc/server-common-go/pkg/configuration"
+	"p2pderivatives-oracle/internal/cfddlccrypto"
 	"p2pderivatives-oracle/internal/oracle"
 	"path/filepath"
 	"runtime"
+
+	conf "github.com/cryptogarageinc/server-common-go/pkg/configuration"
 
 	"github.com/go-resty/resty/v2"
 )
@@ -99,7 +101,7 @@ func InitHelper() {
 		oracleConfig.KeyPassFile = filepath.Join(IntegrationDir, oracleConfig.KeyPassFile)
 	}
 
-	ExpectedOracle, err = oracle.FromConfig(oracleConfig)
+	ExpectedOracle, err = oracle.FromConfig(oracleConfig, cfddlccrypto.NewCfdgoCryptoService())
 	if err != nil {
 		log.Fatalf("Could not instantiate Oracle from config. %v", err)
 	}


### PR DESCRIPTION
The code for the CryptoService interface and the cfdgo implementation are in the same module meaning that code importing the interface indirectly imports the implementation, making it unpractical to test. This refactor extract the cfdgo implementation in a separate module to improve this situation.