### PR TITLE
Refactor/cryptocompare api params

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,31 @@
-# p2pderivatives-oracle
+# P2PDerivatives Oracle
 
-Repository for the P2PDerivatives oracle
+This repository hosts the code for an oracle intended to be used for Discreet Log Contracts (DLC).
+It design to work with price feeds, serving data on a regular basis that can be decided through a configuration.
+See [here](./test/config/default.release.yml) for an example configuration.
+At the moment only the CryptoCompare data feed is supported, but adding support for other feeds can be done by implementing the `DataFeed` interface.
+It is possible to run the oracle without a CryptoCompare API key but only a few requests can be made.
+
+The description of the API can be found [here](./api/README.md).
+
+## Trying it out
+
+To quickly try out the oracle:
+
+```bash
+make gen
+docker-compose up
+```
+
+The oracle should then be running on port 8080 and you can access it through your web browser.
+To see the list of assets (by default btc/usd and btc/jpy):
+- localhost:8080/asset
+
+To get an announcement for an event (replace the date as adequate):
+- http://localhost:8080/asset/btcusd/announcement/2021-02-15T05:32:00Z
+
+To get an attestation for an event (replace the date as adequate):
+- http://localhost:8080/asset/btcusd/attestation/2021-02-08T05:32:00Z
 
 ## Requirements
 

--- a/internal/api/asset_controller.go
+++ b/internal/api/asset_controller.go
@@ -136,9 +136,8 @@ func (ct *AssetController) GetAssetAttestation(c *gin.Context) {
 			return
 		}
 		if !dlcData.HasSignature() {
-			asset, currency := ParseAssetID(ct.assetID)
 			feed := c.MustGet(ContextIDDataFeed).(datafeed.DataFeed)
-			value, err := feed.FindPastAssetPrice(asset, currency, dlcData.PublishedDate)
+			value, err := feed.FindPastAssetPrice(ct.assetID, dlcData.PublishedDate)
 			if err != nil {
 				c.Error(NewUnknownDataFeedError(err))
 				return
@@ -266,9 +265,4 @@ func ParseTime(timeParam string) (*time.Time, error) {
 	}
 	utc := timestamp.UTC()
 	return &utc, nil
-}
-
-// ParseAssetID will return the asset and currency related to the asset id
-func ParseAssetID(assetID string) (asset string, currency string) {
-	return assetID[0:3], assetID[3:6]
 }

--- a/internal/api/asset_controller_test.go
+++ b/internal/api/asset_controller_test.go
@@ -289,7 +289,7 @@ func TestAssetController_GetAssetAttestation_NotInDB_ReturnsCorrectValue(t *test
 		}
 		// mock datafeed
 		feed := mock_datafeed.NewMockDataFeed(ctrl)
-		feed.EXPECT().FindPastAssetPrice("btc", "usd", expectedDate).Return(sigValue, nil)
+		feed.EXPECT().FindPastAssetPrice("btcusd", expectedDate).Return(sigValue, nil)
 		// mock crypto
 		crypto := mock_dlccrypto.NewMockCryptoService(ctrl)
 		for i := 0; i < len(kvalues); i++ {

--- a/internal/cryptocompare/client_config.go
+++ b/internal/cryptocompare/client_config.go
@@ -2,6 +2,13 @@ package cryptocompare
 
 // Config represents the crypto compare client configuration
 type Config struct {
-	APIBaseURL string `configkey:"cryptoCompare.baseUrl" validate:"required"`
-	APIKey     string `configkey:"cryptoCompare.apiKey" validate:"required"`
+	APIBaseURL   string                   `configkey:"cryptoCompare.baseUrl" validate:"required"`
+	APIKey       string                   `configkey:"cryptoCompare.apiKey"`
+	AssetsConfig map[string]CCAssetConfig `configkey:"cryptocompare.assetsConfig" validate:"required"`
+}
+
+// CCAssetConfig contains the request parameters to use for an asset
+type CCAssetConfig struct {
+	fsym  string
+	tsyms string
 }

--- a/internal/datafeed/datafeed.go
+++ b/internal/datafeed/datafeed.go
@@ -9,6 +9,6 @@ type DataFeed interface {
 
 // AssetPriceFeed interface represents a datafeed which implemented price related services
 type AssetPriceFeed interface {
-	FindCurrentAssetPrice(assetID string, currency string) (*float64, error)
-	FindPastAssetPrice(assetID string, currency string, date time.Time) (*float64, error)
+	FindCurrentAssetPrice(assetID string) (*float64, error)
+	FindPastAssetPrice(assetID string, date time.Time) (*float64, error)
 }

--- a/internal/datafeed/dummy_datafeed.go
+++ b/internal/datafeed/dummy_datafeed.go
@@ -15,12 +15,12 @@ type dummyDataFeed struct {
 	config *DummyConfig
 }
 
-func (d *dummyDataFeed) FindCurrentAssetPrice(assetID string, currency string) (*float64, error) {
+func (d *dummyDataFeed) FindCurrentAssetPrice(assetID string) (*float64, error) {
 	f := d.config.ReturnValue
 	return &f, nil
 }
 
-func (d *dummyDataFeed) FindPastAssetPrice(assetID string, currency string, date time.Time) (*float64, error) {
+func (d *dummyDataFeed) FindPastAssetPrice(assetID string, date time.Time) (*float64, error) {
 	f := d.config.ReturnValue
 	return &f, nil
 }

--- a/test/config/default.release.yml
+++ b/test/config/default.release.yml
@@ -41,3 +41,10 @@ api:
 datafeed:
   cryptoCompare:
     baseUrl: https://min-api.cryptocompare.com/data
+    assetConfigs:
+      btcusd:
+        fsym: "btc"
+        tsym: "usd"
+      btcjpy:
+        fsym: "btc"
+        tsym: "jpy"

--- a/test/config/default.release.yml
+++ b/test/config/default.release.yml
@@ -1,7 +1,9 @@
 server:
   address: "0.0.0.0:8080"
 oracle:
+  # the private key of the oracle
   keyFile: /key/key.pem
+  # the password protecting the pem file
   keyPass:
     file: /key/pass.txt
 log:
@@ -19,13 +21,20 @@ database:
   dbuser: postgres
   dbname: db
 api:
+  # the list of assets provided by this oracle
   assets:
     btcusd:
+      # the base date from which the release dates are computed
       startDate: 2020-01-01T00:00:00Z
+      # frequency at which events are served (ISO8601)
       frequency: PT1H
+      # maximum period until which events are served (ISO8601)
       range: P2MT
+      # unit of the asset being served
       unit: usd/btc
+      # precision for the data being served (see https://github.com/discreetlogcontracts/dlcspecs/blob/master/Oracle.md#digit-decomposition)
       precision: 0
+      # configuration for digit decomposition (see https://github.com/discreetlogcontracts/dlcspecs/blob/master/Oracle.md#digit-decomposition)
       signconfig:
         base: 2
         nbDigits: 20
@@ -38,9 +47,14 @@ api:
       signconfig:
         base: 2
         nbDigits: 20
+# configuration for the data feed
 datafeed:
   cryptoCompare:
     baseUrl: https://min-api.cryptocompare.com/data
+    # Set your cryptocompare api key here
+    # apiKey: xxxxxxxx
+    # CryptoCompare parameters for each asset. fsym is the cryptocurrency symbol
+    # of interest while tsym is the currency symbol to convert to.
     assetConfigs:
       btcusd:
         fsym: "btc"

--- a/test/config/integration.yaml
+++ b/test/config/integration.yaml
@@ -47,5 +47,12 @@ api:
 datafeed:
   cryptoCompare:
     baseUrl: https://min-api.cryptocompare.com/data
+    assetConfigs:
+      btcusd:
+        fsym: "btc"
+        tsym: "usd"
+      btcjpy:
+        fsym: "btc"
+        tsym: "jpy"
   dummy:
     returnValue: 9000

--- a/test/mock/datafeed/mock_datafeed.go
+++ b/test/mock/datafeed/mock_datafeed.go
@@ -10,108 +10,108 @@ import (
 	time "time"
 )
 
-// MockDataFeed is a mock of DataFeed interface.
+// MockDataFeed is a mock of DataFeed interface
 type MockDataFeed struct {
 	ctrl     *gomock.Controller
 	recorder *MockDataFeedMockRecorder
 }
 
-// MockDataFeedMockRecorder is the mock recorder for MockDataFeed.
+// MockDataFeedMockRecorder is the mock recorder for MockDataFeed
 type MockDataFeedMockRecorder struct {
 	mock *MockDataFeed
 }
 
-// NewMockDataFeed creates a new mock instance.
+// NewMockDataFeed creates a new mock instance
 func NewMockDataFeed(ctrl *gomock.Controller) *MockDataFeed {
 	mock := &MockDataFeed{ctrl: ctrl}
 	mock.recorder = &MockDataFeedMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockDataFeed) EXPECT() *MockDataFeedMockRecorder {
 	return m.recorder
 }
 
-// FindCurrentAssetPrice mocks base method.
-func (m *MockDataFeed) FindCurrentAssetPrice(assetID, currency string) (*float64, error) {
+// FindCurrentAssetPrice mocks base method
+func (m *MockDataFeed) FindCurrentAssetPrice(assetID string) (*float64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindCurrentAssetPrice", assetID, currency)
+	ret := m.ctrl.Call(m, "FindCurrentAssetPrice", assetID)
 	ret0, _ := ret[0].(*float64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// FindCurrentAssetPrice indicates an expected call of FindCurrentAssetPrice.
-func (mr *MockDataFeedMockRecorder) FindCurrentAssetPrice(assetID, currency interface{}) *gomock.Call {
+// FindCurrentAssetPrice indicates an expected call of FindCurrentAssetPrice
+func (mr *MockDataFeedMockRecorder) FindCurrentAssetPrice(assetID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindCurrentAssetPrice", reflect.TypeOf((*MockDataFeed)(nil).FindCurrentAssetPrice), assetID, currency)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindCurrentAssetPrice", reflect.TypeOf((*MockDataFeed)(nil).FindCurrentAssetPrice), assetID)
 }
 
-// FindPastAssetPrice mocks base method.
-func (m *MockDataFeed) FindPastAssetPrice(assetID, currency string, date time.Time) (*float64, error) {
+// FindPastAssetPrice mocks base method
+func (m *MockDataFeed) FindPastAssetPrice(assetID string, date time.Time) (*float64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindPastAssetPrice", assetID, currency, date)
+	ret := m.ctrl.Call(m, "FindPastAssetPrice", assetID, date)
 	ret0, _ := ret[0].(*float64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// FindPastAssetPrice indicates an expected call of FindPastAssetPrice.
-func (mr *MockDataFeedMockRecorder) FindPastAssetPrice(assetID, currency, date interface{}) *gomock.Call {
+// FindPastAssetPrice indicates an expected call of FindPastAssetPrice
+func (mr *MockDataFeedMockRecorder) FindPastAssetPrice(assetID, date interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindPastAssetPrice", reflect.TypeOf((*MockDataFeed)(nil).FindPastAssetPrice), assetID, currency, date)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindPastAssetPrice", reflect.TypeOf((*MockDataFeed)(nil).FindPastAssetPrice), assetID, date)
 }
 
-// MockAssetPriceFeed is a mock of AssetPriceFeed interface.
+// MockAssetPriceFeed is a mock of AssetPriceFeed interface
 type MockAssetPriceFeed struct {
 	ctrl     *gomock.Controller
 	recorder *MockAssetPriceFeedMockRecorder
 }
 
-// MockAssetPriceFeedMockRecorder is the mock recorder for MockAssetPriceFeed.
+// MockAssetPriceFeedMockRecorder is the mock recorder for MockAssetPriceFeed
 type MockAssetPriceFeedMockRecorder struct {
 	mock *MockAssetPriceFeed
 }
 
-// NewMockAssetPriceFeed creates a new mock instance.
+// NewMockAssetPriceFeed creates a new mock instance
 func NewMockAssetPriceFeed(ctrl *gomock.Controller) *MockAssetPriceFeed {
 	mock := &MockAssetPriceFeed{ctrl: ctrl}
 	mock.recorder = &MockAssetPriceFeedMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockAssetPriceFeed) EXPECT() *MockAssetPriceFeedMockRecorder {
 	return m.recorder
 }
 
-// FindCurrentAssetPrice mocks base method.
-func (m *MockAssetPriceFeed) FindCurrentAssetPrice(assetID, currency string) (*float64, error) {
+// FindCurrentAssetPrice mocks base method
+func (m *MockAssetPriceFeed) FindCurrentAssetPrice(assetID string) (*float64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindCurrentAssetPrice", assetID, currency)
+	ret := m.ctrl.Call(m, "FindCurrentAssetPrice", assetID)
 	ret0, _ := ret[0].(*float64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// FindCurrentAssetPrice indicates an expected call of FindCurrentAssetPrice.
-func (mr *MockAssetPriceFeedMockRecorder) FindCurrentAssetPrice(assetID, currency interface{}) *gomock.Call {
+// FindCurrentAssetPrice indicates an expected call of FindCurrentAssetPrice
+func (mr *MockAssetPriceFeedMockRecorder) FindCurrentAssetPrice(assetID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindCurrentAssetPrice", reflect.TypeOf((*MockAssetPriceFeed)(nil).FindCurrentAssetPrice), assetID, currency)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindCurrentAssetPrice", reflect.TypeOf((*MockAssetPriceFeed)(nil).FindCurrentAssetPrice), assetID)
 }
 
-// FindPastAssetPrice mocks base method.
-func (m *MockAssetPriceFeed) FindPastAssetPrice(assetID, currency string, date time.Time) (*float64, error) {
+// FindPastAssetPrice mocks base method
+func (m *MockAssetPriceFeed) FindPastAssetPrice(assetID string, date time.Time) (*float64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindPastAssetPrice", assetID, currency, date)
+	ret := m.ctrl.Call(m, "FindPastAssetPrice", assetID, date)
 	ret0, _ := ret[0].(*float64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// FindPastAssetPrice indicates an expected call of FindPastAssetPrice.
-func (mr *MockAssetPriceFeedMockRecorder) FindPastAssetPrice(assetID, currency, date interface{}) *gomock.Call {
+// FindPastAssetPrice indicates an expected call of FindPastAssetPrice
+func (mr *MockAssetPriceFeedMockRecorder) FindPastAssetPrice(assetID, date interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindPastAssetPrice", reflect.TypeOf((*MockAssetPriceFeed)(nil).FindPastAssetPrice), assetID, currency, date)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindPastAssetPrice", reflect.TypeOf((*MockAssetPriceFeed)(nil).FindPastAssetPrice), assetID, date)
 }

--- a/test/mock/dlccrypto/mock_crypto_service.go
+++ b/test/mock/dlccrypto/mock_crypto_service.go
@@ -10,30 +10,30 @@ import (
 	reflect "reflect"
 )
 
-// MockCryptoService is a mock of CryptoService interface.
+// MockCryptoService is a mock of CryptoService interface
 type MockCryptoService struct {
 	ctrl     *gomock.Controller
 	recorder *MockCryptoServiceMockRecorder
 }
 
-// MockCryptoServiceMockRecorder is the mock recorder for MockCryptoService.
+// MockCryptoServiceMockRecorder is the mock recorder for MockCryptoService
 type MockCryptoServiceMockRecorder struct {
 	mock *MockCryptoService
 }
 
-// NewMockCryptoService creates a new mock instance.
+// NewMockCryptoService creates a new mock instance
 func NewMockCryptoService(ctrl *gomock.Controller) *MockCryptoService {
 	mock := &MockCryptoService{ctrl: ctrl}
 	mock.recorder = &MockCryptoServiceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockCryptoService) EXPECT() *MockCryptoServiceMockRecorder {
 	return m.recorder
 }
 
-// GenerateSchnorrKeyPair mocks base method.
+// GenerateSchnorrKeyPair mocks base method
 func (m *MockCryptoService) GenerateSchnorrKeyPair() (*dlccrypto.PrivateKey, *dlccrypto.SchnorrPublicKey, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GenerateSchnorrKeyPair")
@@ -43,13 +43,13 @@ func (m *MockCryptoService) GenerateSchnorrKeyPair() (*dlccrypto.PrivateKey, *dl
 	return ret0, ret1, ret2
 }
 
-// GenerateSchnorrKeyPair indicates an expected call of GenerateSchnorrKeyPair.
+// GenerateSchnorrKeyPair indicates an expected call of GenerateSchnorrKeyPair
 func (mr *MockCryptoServiceMockRecorder) GenerateSchnorrKeyPair() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateSchnorrKeyPair", reflect.TypeOf((*MockCryptoService)(nil).GenerateSchnorrKeyPair))
 }
 
-// SchnorrPublicKeyFromPrivateKey mocks base method.
+// SchnorrPublicKeyFromPrivateKey mocks base method
 func (m *MockCryptoService) SchnorrPublicKeyFromPrivateKey(privateKey *dlccrypto.PrivateKey) (*dlccrypto.SchnorrPublicKey, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SchnorrPublicKeyFromPrivateKey", privateKey)
@@ -58,13 +58,13 @@ func (m *MockCryptoService) SchnorrPublicKeyFromPrivateKey(privateKey *dlccrypto
 	return ret0, ret1
 }
 
-// SchnorrPublicKeyFromPrivateKey indicates an expected call of SchnorrPublicKeyFromPrivateKey.
+// SchnorrPublicKeyFromPrivateKey indicates an expected call of SchnorrPublicKeyFromPrivateKey
 func (mr *MockCryptoServiceMockRecorder) SchnorrPublicKeyFromPrivateKey(privateKey interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SchnorrPublicKeyFromPrivateKey", reflect.TypeOf((*MockCryptoService)(nil).SchnorrPublicKeyFromPrivateKey), privateKey)
 }
 
-// ComputeSchnorrSignature mocks base method.
+// ComputeSchnorrSignature mocks base method
 func (m *MockCryptoService) ComputeSchnorrSignature(privateKey, oneTimeSigningK *dlccrypto.PrivateKey, message string) (*dlccrypto.Signature, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ComputeSchnorrSignature", privateKey, oneTimeSigningK, message)
@@ -73,13 +73,13 @@ func (m *MockCryptoService) ComputeSchnorrSignature(privateKey, oneTimeSigningK 
 	return ret0, ret1
 }
 
-// ComputeSchnorrSignature indicates an expected call of ComputeSchnorrSignature.
+// ComputeSchnorrSignature indicates an expected call of ComputeSchnorrSignature
 func (mr *MockCryptoServiceMockRecorder) ComputeSchnorrSignature(privateKey, oneTimeSigningK, message interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ComputeSchnorrSignature", reflect.TypeOf((*MockCryptoService)(nil).ComputeSchnorrSignature), privateKey, oneTimeSigningK, message)
 }
 
-// VerifySchnorrSignature mocks base method.
+// VerifySchnorrSignature mocks base method
 func (m *MockCryptoService) VerifySchnorrSignature(publicKey *dlccrypto.SchnorrPublicKey, signature *dlccrypto.Signature, message string) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "VerifySchnorrSignature", publicKey, signature, message)
@@ -88,7 +88,7 @@ func (m *MockCryptoService) VerifySchnorrSignature(publicKey *dlccrypto.SchnorrP
 	return ret0, ret1
 }
 
-// VerifySchnorrSignature indicates an expected call of VerifySchnorrSignature.
+// VerifySchnorrSignature indicates an expected call of VerifySchnorrSignature
 func (mr *MockCryptoServiceMockRecorder) VerifySchnorrSignature(publicKey, signature, message interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifySchnorrSignature", reflect.TypeOf((*MockCryptoService)(nil).VerifySchnorrSignature), publicKey, signature, message)


### PR DESCRIPTION
* Refactor config to take cryptocompare parameters as part of cryptocompare config parameters.
* Update README to add explanation about what the oracle is and how to quickly get it running.